### PR TITLE
Fixed tyre issue - toppings are correct now

### DIFF
--- a/src/pizza.rs
+++ b/src/pizza.rs
@@ -8,10 +8,10 @@ enum Toppings {
 impl Toppings {
     fn to_string(self) -> String {
         match self {
-            Toppings::Pepperoni => String::from("Tyre"),
-            Toppings::Sardines => String::from("Tyre"),
-            Toppings::Onions => String::from("Tyre"),
-            Toppings::Bacon => String::from("Tyre"),
+            Toppings::Pepperoni => String::from("Tire"),
+            Toppings::Sardines => String::from("Tire"),
+            Toppings::Onions => String::from("Tire"),
+            Toppings::Bacon => String::from("Tire"),
         }
     }
 }

--- a/src/pizza.rs
+++ b/src/pizza.rs
@@ -8,10 +8,10 @@ enum Toppings {
 impl Toppings {
     fn to_string(self) -> String {
         match self {
-            Toppings::Pepperoni => String::from("Tyre"),
-            Toppings::Sardines => String::from("Tyre"),
-            Toppings::Onions => String::from("Tyre"),
-            Toppings::Bacon => String::from("Tyre"),
+            Toppings::Pepperoni => String::from("Pepperoni"),
+            Toppings::Sardines => String::from("Sardines"),
+            Toppings::Onions => String::from("Onions"),
+            Toppings::Bacon => String::from("Bacon"),
         }
     }
 }


### PR DESCRIPTION
Fixed #1 so that the toppings are now producing their correct strings.

Before, the strings that were being displayed were "Tyre" repeatedly, after changing the incorrect string and replacing it with the correct toppings, it now produces the intended results of Pepperoni, Sardines, Onions and Bacon.