### PR TITLE
Available toppings now display properly

### DIFF
--- a/src/pizza.rs
+++ b/src/pizza.rs
@@ -8,10 +8,10 @@ enum Toppings {
 impl Toppings {
     fn to_string(self) -> String {
         match self {
-            Toppings::Pepperoni => String::from("Tire"),
-            Toppings::Sardines => String::from("Tire"),
-            Toppings::Onions => String::from("Tire"),
-            Toppings::Bacon => String::from("Tire"),
+            Toppings::Pepperoni => String::from("Pepperoni"),
+            Toppings::Sardines => String::from("Sardines"),
+            Toppings::Onions => String::from("Onions"),
+            Toppings::Bacon => String::from("Bacon"),
         }
     }
 }


### PR DESCRIPTION
Fixed #5, getting rid of the tire issue. I changed the strings that were displaying "tire" from the `available_toppings` function to the correct toppings -- pepperoni, onions, sardines, and bacon.