### PR TITLE
Makes available toppings function present the correct toppings

### DIFF
--- a/src/pizza.rs
+++ b/src/pizza.rs
@@ -8,10 +8,10 @@ enum Toppings {
 impl Toppings {
     fn to_string(self) -> String {
         match self {
-            Toppings::Pepperoni => String::from("Tire"),
-            Toppings::Sardines => String::from("Tire"),
-            Toppings::Onions => String::from("Tire"),
-            Toppings::Bacon => String::from("Tire"),
+            Toppings::Pepperoni => String::from("Pepperoni"),
+            Toppings::Sardines => String::from("Sardines"),
+            Toppings::Onions => String::from("Onions"),
+            Toppings::Bacon => String::from("Bacon"),
         }
     }
 }


### PR DESCRIPTION
Fixes #7 by changing the `available_toppings` to correctly return the strings pepperoni, onions, bacon, and sardines. Previously, it was returning "tire" no matter what topping was chosen.